### PR TITLE
fix-cpu-temp-check

### DIFF
--- a/synth-shell-greeter/info.sh
+++ b/synth-shell-greeter/info.sh
@@ -204,7 +204,7 @@ printInfoColorpaletteFancy()
 ##
 printInfoCPUTemp()
 {
-	if ( which sensors > /dev/null 2>&1 ); then
+	if ( which sensors > /dev/null 2>&1 && sensors > /dev/null 2>&1); then
 
 		## GET VALUES
 		local temp_line=$(sensors 2>/dev/null |\


### PR DESCRIPTION
Added edge case in printInfoCPUTemp for when the sensors command returns an error (usually because the host is a VM).