### PR TITLE
Fix errors with "binary operator expected"

### DIFF
--- a/synth-shell-greeter/info.sh
+++ b/synth-shell-greeter/info.sh
@@ -31,7 +31,7 @@
 ##==============================================================================
 ##	EXTERNAL DEPENDENCIES
 ##==============================================================================
-[ "$(type -t include)" != 'function' ]&&{ include(){ { [ -z "$_IR" ]&&_IR="$PWD"&&cd $(dirname "${BASH_SOURCE[0]}")&&include "$1"&&cd "$_IR"&&unset _IR;}||{ local d=$PWD&&cd "$(dirname "$PWD/$1")"&&. "$(basename "$1")"&&cd "$d";}||{ echo "Include failed $PWD->$1"&&exit 1;};};}
+[ "$(type -t include)" != 'function' ]&&{ include(){ { [ -z "$_IR" ]&&_IR="$PWD"&&cd "$(dirname "${BASH_SOURCE[0]}")"&&include "$1"&&cd "$_IR"&&unset _IR;}||{ local d="$PWD"&&cd "$(dirname "$PWD/$1")"&&. "$(basename "$1")"&&cd "$d";}||{ echo "Include failed $PWD->$1"&&exit 1;};};}
 
 include 'info_print_info.sh'
 include 'info_about_os.sh'
@@ -126,7 +126,7 @@ printInfoGPU()
 ##
 printInfoSystemctl()
 {
-	if [ -z $(pidof systemd) ]; then
+	if [ -z "$(pidof systemd)" ]; then
 		local sysctl="systemd not running"
 		local state="critical"
 
@@ -450,6 +450,4 @@ printMonitorCPUTemp()
 		printInfoLine "CPU temp" "lm-sensors not installed"
 	fi
 }
-
-	
 

--- a/synth-shell-greeter/reports.sh
+++ b/synth-shell-greeter/reports.sh
@@ -31,7 +31,7 @@
 ##==============================================================================
 ##	EXTERNAL DEPENDENCIES
 ##==============================================================================
-[ "$(type -t include)" != 'function' ]&&{ include(){ { [ -z "$_IR" ]&&_IR="$PWD"&&cd $(dirname "${BASH_SOURCE[0]}")&&include "$1"&&cd "$_IR"&&unset _IR;}||{ local d=$PWD&&cd "$(dirname "$PWD/$1")"&&. "$(basename "$1")"&&cd "$d";}||{ echo "Include failed $PWD->$1"&&exit 1;};};}
+[ "$(type -t include)" != 'function' ]&&{ include(){ { [ -z "$_IR" ]&&_IR="$PWD"&&cd "$(dirname "${BASH_SOURCE[0]}")"&&include "$1"&&cd "$_IR"&&unset _IR;}||{ local d="$PWD"&&cd "$(dirname "$PWD/$1")"&&. "$(basename "$1")"&&cd "$d";}||{ echo "Include failed $PWD->$1"&&exit 1;};};}
 
 include '../bash-tools/bash-tools/color.sh'
 include '../bash-tools/bash-tools/print_utils.sh'
@@ -78,7 +78,7 @@ reportSystemctl()
     ## 1. Check if systemd is running (it might not on some distros/Windows)
     ## 2. Get number of failed daemons
     ## 3. Report those that failed
-    if [ ! -z $(pidof systemd) ]; then
+    if [ -n "$(pidof systemd)" ]; then
 	    systcl_num_failed=$(systemctl --failed |\
 	                        grep "loaded units listed" |\
 	                        head -c 1)
@@ -109,7 +109,7 @@ reportHogsCPU()
 
 
 	## EXIT IF NOT ENABLED
-	if [ "$cpu_crit_print"==true ]; then
+	if [ "$cpu_crit_print" == true ]; then
 		## CHECK CPU LOAD
 		local current=$(awk '{avg_1m=($1)} END {printf "%3.2f", avg_1m}' /proc/loadavg)
 		local max=$(nproc --all)
@@ -163,7 +163,7 @@ reportHogsMemory()
 
 
 	## EXIT IF NOT ENABLED
-	if [ "$ram_crit_print"==true ]; then
+	if [ "$ram_crit_print" == true ]; then
 		## CHECK RAM
 		local ram_is_crit=false
 		local mem_info=$('free' -m | head -n 2 | tail -n 1)
@@ -177,7 +177,7 @@ reportHogsMemory()
 
 		## CHECK SWAP
 		## First check if there is any swap at all by checking /proc/swaps
-		## If tehre is at least one swap partition listed, proceed
+		## If there is at least one swap partition listed, proceed
 		local swap_is_crit=false
 		local num_swap_devs=$(($(wc -l /proc/swaps | awk '{print $1;}') -1))	
 		if [ "$num_swap_devs" -ge 1 ]; then

--- a/synth-shell-greeter/synth-shell-greeter.sh
+++ b/synth-shell-greeter/synth-shell-greeter.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# shellcheck disable=SC2155,SC2059,SC2004,SC1090,SC2154,SC2034
-
 ##  +-----------------------------------+-----------------------------------+
 ##  |                                                                       |
 ##  | Copyright (c) 2019-2020, Andres Gongora <mail@andresgongora.com>.     |

--- a/synth-shell-greeter/synth-shell-greeter.sh
+++ b/synth-shell-greeter/synth-shell-greeter.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# shellcheck disable=SC2155,SC2059,SC2004,SC1090,SC2154,SC2034
+
 ##  +-----------------------------------+-----------------------------------+
 ##  |                                                                       |
 ##  | Copyright (c) 2019-2020, Andres Gongora <mail@andresgongora.com>.     |
@@ -33,7 +35,7 @@
 ##==============================================================================
 ##	EXTERNAL DEPENDENCIES
 ##==============================================================================
-[ "$(type -t include)" != 'function' ]&&{ include(){ { [ -z "$_IR" ]&&_IR="$PWD"&&cd $(dirname "${BASH_SOURCE[0]}")&&include "$1"&&cd "$_IR"&&unset _IR;}||{ local d=$PWD&&cd "$(dirname "$PWD/$1")"&&. "$(basename "$1")"&&cd "$d";}||{ echo "Include failed $PWD->$1"&&exit 1;};};}
+[ "$(type -t include)" != 'function' ]&&{ include(){ { [ -z "$_IR" ]&&_IR="$PWD"&&cd "$(dirname "${BASH_SOURCE[0]}")"&&include "$1"&&cd "$_IR"&&unset _IR;}||{ local d="$PWD"&&cd "$(dirname "$PWD/$1")"&&. "$(basename "$1")"&&cd "$d";}||{ echo "Include failed $PWD->$1"&&exit 1;};};}
 
 include '../bash-tools/bash-tools/color.sh'
 include '../bash-tools/bash-tools/print_utils.sh'
@@ -69,7 +71,7 @@ local sys_config_file="/etc/synth-shell/synth-shell-greeter.config"
 
 if   [ -f "$target_config_file" ]; then source "$target_config_file" ;
 elif [ -f "$user_config_file" ]; then source "$user_config_file" ;
-elif [ -f $root_config_file -a "$USER" == "root" ]; then source "$root_config_file" ;
+elif [ -f $root_config_file ] && [ "$USER" == "root" ]; then source "$root_config_file" ;
 elif [ -f "$sys_config_file" ]; then source "$sys_config_file" ;
 else : # Default config already "included" ; 
 fi
@@ -152,9 +154,9 @@ printStatusInfo()
 	local status_info=""
 	for key in $print_info; do
 		if [ -z "$status_info" ]; then
-			local status_info="$(statusSwitch $key)"
+			local status_info="$(statusSwitch "$key")"
 		else
-			local status_info="${status_info}\n$(statusSwitch $key)"
+			local status_info="${status_info}\n$(statusSwitch "$key")"
 		fi
 	done
 	printf "${status_info}\n"
@@ -185,7 +187,7 @@ printHeader()
 
 
 	## PRINT ONLY WHAT FITS IN THE TERMINAL
-	if [ $(( $logo_cols + $info_cols )) -le $term_cols ]; then
+	if [ $(( $logo_cols + $info_cols )) -le "$term_cols" ]; then
 		: # everything fits
 	else
 		local logo=""
@@ -221,7 +223,7 @@ printReports()
 
 
 ## CHECKS
-if [ -z $(which 'bc' 2>/dev/null) ]; then
+if [ -z "$(which 'bc' 2>/dev/null)" ]; then
 	printf "${fc_error}synth-shell-greeter: 'bc' not installed${fc_none}"
 	exit 1
 fi
@@ -251,7 +253,7 @@ if $print_extra_new_line_bot; then echo ""; fi
 ## If not running interactively, don't do anything.
 ## Run with `LANG=C` so the code uses `.` as decimal separator.
 if [ -n "$( echo $- | grep i )" ]; then
-	(LC_ALL=C greeter $1) 
+	(LC_ALL=C greeter "$1") 
 fi
 unset greeter
 


### PR DESCRIPTION
When the greeter started, I'd get: bash: `[: 831: binary operator expected` above and below the displayed information. So I poured over some of the scripts with `shellcheck` and fixed what was showing up as errors while trying to not break other stuff.

![image](https://user-images.githubusercontent.com/1703958/106852497-89e7ef80-668e-11eb-9bfe-c4a4aff8cb74.png)


This at least fixed all but one issue on my system.
