### PR TITLE
Fix OS detection on Debian 11

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -130,7 +130,7 @@ CONFIG_FILE="$OUTPUT_CONFIG_DIR/synth-shell-greeter.config"
 if [ -f "$CONFIG_FILE" ]; then
 	CONFIG_FILE="${CONFIG_FILE}.new"
 fi
-DISTRO=$(cat /etc/os-release | grep "ID=" | sed 's/ID=//g' | head -n 1)
+DISTRO=$(cat /etc/os-release | grep "^ID=" | sed 's/ID=//g' | head -n 1)
 case "$DISTRO" in
 	'arch' )	cp "$INPUT_CONFIG_DIR/os/synth-shell-greeter.archlinux.config" "$CONFIG_FILE" ;;
 	'manjaro' )	cp "$INPUT_CONFIG_DIR/os/synth-shell-greeter.manjaro.config" "$CONFIG_FILE" ;;


### PR DESCRIPTION
- Changed the regexp that populates the DISTRO variable to only match the correct line from /etc/os-release on Debian 11
- Fixes #34